### PR TITLE
Optimize helm install/uninstall to avoid releases listing

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -534,12 +534,13 @@ func (i *Install) availableName() error {
 		return nil
 	}
 
-	h, err := i.cfg.Releases.History(start)
-	if err != nil || len(h) < 1 {
-		return nil
+	rel, err := i.cfg.Releases.Get(start, 1)
+	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return nil
+		}
+		return fmt.Errorf("fail to get release \"%s\": %v", start, err)
 	}
-	releaseutil.Reverse(h, releaseutil.SortByRevision)
-	rel := h[0]
 
 	if st := rel.Info.Status; i.Replace && (st == release.StatusUninstalled || st == release.StatusFailed) {
 		return nil

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -73,19 +73,17 @@ func (u *Uninstall) Run(name string) (*release.UninstallReleaseResponse, error) 
 		return nil, errors.Errorf("uninstall: Release name is invalid: %s", name)
 	}
 
-	rels, err := u.cfg.Releases.History(name)
+	rel, err := u.cfg.Releases.Get(name, 1)
 	if err != nil {
 		if u.IgnoreNotFound {
 			return nil, nil
 		}
 		return nil, errors.Wrapf(err, "uninstall: Release not loaded: %s", name)
 	}
-	if len(rels) < 1 {
+	if rel == nil {
 		return nil, errMissingRelease
 	}
-
-	releaseutil.SortByRevision(rels)
-	rel := rels[len(rels)-1]
+	rels := []*release.Release{rel}
 
 	// TODO: Are there any cases where we want to force a delete even if it's
 	// already marked deleted?


### PR DESCRIPTION
In Fluid, there is only a unique version of runtime when deploying through Helm. Therefore, the logic for confirming the version by listing release configmaps during helm install/uninstall should be optimized to use the get method to retrieve version 1. This reduces the pressure of list operations on the apiserver.

